### PR TITLE
mozillascience.org redirect rules

### DIFF
--- a/app/react/main.jsx
+++ b/app/react/main.jsx
@@ -63,7 +63,7 @@ render((
       <Route path="code-of-conduct" component={CodeOfConduct}/>
 
       // Redirect old Science site URLs
-      <Redirect from="training" to="programs" />
+      <Redirect from="training" to="resources" />
       <Redirect from="community" to="programs/events" />
       <Redirect from="collaborate" to="projects" />
       <Redirect from="about" to="/" />

--- a/app/react/main.jsx
+++ b/app/react/main.jsx
@@ -76,7 +76,6 @@ render((
       <Redirect from="community-call-jun-09-11-et" to="/programs/events/community-call-jun-09-11-et" />
       <Redirect from="project-call-may-26" to="/programs/events/project-call-may-26" />
       <Redirect from="project-call-april-28" to="/programs/events/project-call-april-28" />
-      <Redirect from="space-apps-2016" to="/programs/events/space-apps-2016" />
       <Redirect from="community-call-apr-14-11-et" to="/programs/events/community-call-apr-14-11-et" />
       <Redirect from="project-call-march-24" to="/programs/events/project-call-march-24" />
       <Redirect from="community-call-mar-10-11-et" to="/programs/events/community-call-mar-10-11-et" />

--- a/app/react/main.jsx
+++ b/app/react/main.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "react-dom";
-import { Router, Route, browserHistory, IndexRoute, applyRouterMiddleware } from "react-router";
+import { Router, Route, Redirect, browserHistory, IndexRoute, applyRouterMiddleware } from "react-router";
 import useScroll from 'react-router-scroll';
 
 // Components
@@ -48,8 +48,11 @@ render((
       <Route path="blog" component={BlogList}/>
       <Route path="blog/:slug" component={BlogPost}/>
       <Route path="members" component={Members}/>
+      <Route path="projects" component={Projects} >
+        // https://github.com/mozilla/science.mozilla.org/issues/425#issuecomment-221339156
+        <Redirect from="jstirnaman-openMetaAnalysis.github.io" to="openMetaAnalysis" />
+      </Route>
       <Route path="projects/:id" component={Project} />
-      <Route path="projects" component={Projects} />
       <Route path="programs/events/:id" component={Event} />
       <Route path="programs/events" component={Events} />
       <Route path="programs/fellowships" component={Fellowships} />
@@ -58,6 +61,40 @@ render((
       <Route path="resources" component={Resources}/>
       <Route path="style-guide" component={StyleGuide}/>
       <Route path="code-of-conduct" component={CodeOfConduct}/>
+
+      // Redirect old Science site URLs
+      <Redirect from="training" to="programs" />
+      <Redirect from="community" to="programs/events" />
+      <Redirect from="collaborate" to="projects" />
+      <Redirect from="about" to="/" />
+      <Redirect from="u/:membername" to="/" />
+      <Redirect from="fellows" to="programs/fellowships" />
+      <Redirect from="fellows/2015" to="programs/fellowships" />
+      <Redirect from="training" to="programs" />
+
+      // Event redirects
+      <Redirect from="community-call-jun-09-11-et" to="/programs/events/community-call-jun-09-11-et" />
+      <Redirect from="project-call-may-26" to="/programs/events/project-call-may-26" />
+      <Redirect from="project-call-april-28" to="/programs/events/project-call-april-28" />
+      <Redirect from="space-apps-2016" to="/programs/events/space-apps-2016" />
+      <Redirect from="community-call-apr-14-11-et" to="/programs/events/community-call-apr-14-11-et" />
+      <Redirect from="project-call-march-24" to="/programs/events/project-call-march-24" />
+      <Redirect from="community-call-mar-10-11-et" to="/programs/events/community-call-mar-10-11-et" />
+      <Redirect from="project-call-feb-25" to="/programs/events/project-call-feb-25" />
+      <Redirect from="community-call-feb-11-11-et" to="/programs/events/community-call-feb-11-11-et" />
+      <Redirect from="working-open-workshop-february-2016" to="/programs/events/working-open-workshop-february-2016" />
+      <Redirect from="working-open-workshop-mixer-february-4th" to="/programs/events/working-open-workshop-mixer-february-4th" />
+      <Redirect from="project-call-jan-28" to="/programs/events/project-call-jan-28" />
+      <Redirect from="community-call-jan-14-11-et" to="/programs/events/community-call-jan-14-11-et" />
+      <Redirect from="open-science-summit-2015" to="/programs/events/open-science-summit-2015" />
+      <Redirect from="toronto-open-science-code-sprint-2015" to="/programs/events/toronto-open-science-code-sprint-2015" />
+      <Redirect from="mozfest-2015" to="/programs/events/mozfest-2015" />
+      <Redirect from="mozfest-2014" to="/programs/events/mozfest-2014" />
+      <Redirect from="global-sprint-2015" to="/programs/events/global-sprint-2015" />
+      <Redirect from="global-sprint-2016" to="/programs/events/global-sprint-2016" />
+
+      // Old blog post URL redirects (no finite list of blog slugs, so using a catch-all)
+      <Redirect from=":post" to="/blog/:post" />
     </Route>
   </Router>
 ), document.querySelector(`#app`));


### PR DESCRIPTION
see: https://github.com/MozillaFoundation/mofo-devops/issues/311

I had to implement the blog post redirect as a catch-all, since there wasn't a finite list of blog slugs.