### PR TITLE
Update punctuations and verbiage

### DIFF
--- a/app/react/pages/fellowships/fellowships.jsx
+++ b/app/react/pages/fellowships/fellowships.jsx
@@ -127,12 +127,12 @@ export default React.createClass({
               <p>Fellows must be:</p>
               <div className="m-b-3">
                 <IconItem imgSrc="/assets/img/fellowships/icon-institution.svg" copy="Currently employed at a research institution"></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-stipend.svg" copy="Have the ability to accept outside funds for this fellowship directly"></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-stipend.svg" copy="Able to accept outside funds for this fellowship directly"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-research.svg" copy="Currently an early-career researcher (i.e, graduate students, post-docs, research scientists, lecturers)"></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-life.svg" copy="Specializing in the life sciences or natural sciences."></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-travel.svg" copy="Able to travel."></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-approve.svg" copy="Supported by their supervisors. As fellows will be based at their home institutions, please note that a letter of support from their supervisor is mandatory for consideration."></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-open.svg" copy="Have experience participating in open communities."></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-life.svg" copy="Specializing in the life sciences or natural sciences"></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-travel.svg" copy="Able to travel"></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-approve.svg" copy="Supported by their supervisors. As fellows will be based at their home institutions, please note that a letter of support from their supervisor is mandatory for consideration"></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-open.svg" copy="Experienced participants in open communities"></IconItem>
               </div>
             </div>
             <div className="p-y-3" name="FAQ" iconDefault="/assets/img/icon-tab-faq.svg" iconActive="/assets/img/icon-tab-faq-blue.svg">

--- a/app/react/pages/fellowships/fellowships.jsx
+++ b/app/react/pages/fellowships/fellowships.jsx
@@ -119,7 +119,7 @@ export default React.createClass({
                 <IconItem imgSrc="/assets/img/fellowships/icon-insurance.svg" copy="A one-time health insurance supplement for Fellows and their families, ranging from $3,500 for single Fellows to $7,000 for a couple with two or more children"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-child.svg" copy="A one-time childcare allotment of up to $6,000 for families with children"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-computer.svg" copy="An allowance of up to $3,000 towards the purchase of laptop computer, digital cameras, recorders and computer software; fees for continuing studies or other courses, research fees or payments, to the extent related to the fellowship"></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-trips.svg" copy="All approved fellowship trips – domestic and international – are covered in full"></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-trips.svg" copy="Funding for relevant fellowship trips - domestic and international - which will be covered in full"></IconItem>
                 * Proposed fellowship amounts are gross amounts and may be reduced by applicable taxes in the various applicable jurisdictions. Read more <a href="#" onClick={this.switchToFAQ}>here</a>
               </div>
 

--- a/app/react/pages/fellowships/fellowships.jsx
+++ b/app/react/pages/fellowships/fellowships.jsx
@@ -117,7 +117,7 @@ export default React.createClass({
               <div className="m-b-3">
                 <IconItem imgSrc="/assets/img/fellowships/icon-stipend.svg" copy="A stipend of $60,000 USD*, paid in 10 monthly installments"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-insurance.svg" copy="A one-time health insurance supplement for Fellows and their families, ranging from $3,500 for single Fellows to $7,000 for a couple with two or more children"></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-child.svg" copy="A one-time childcare allotment of up to $6,000 for families with children."></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-child.svg" copy="A one-time childcare allotment of up to $6,000 for families with children"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-computer.svg" copy="An allowance of up to $3,000 towards the purchase of laptop computer, digital cameras, recorders and computer software; fees for continuing studies or other courses, research fees or payments, to the extent related to the fellowship"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-trips.svg" copy="All approved fellowship trips – domestic and international – are covered in full"></IconItem>
                 * Proposed fellowship amounts are gross amounts and may be reduced by applicable taxes in the various applicable jurisdictions. Read more <a href="#" onClick={this.switchToFAQ}>here</a>

--- a/app/react/pages/fellowships/fellowships.jsx
+++ b/app/react/pages/fellowships/fellowships.jsx
@@ -115,11 +115,11 @@ export default React.createClass({
               <p className="m-b-3">Fellows will receive:</p>
 
               <div className="m-b-3">
-                <IconItem imgSrc="/assets/img/fellowships/icon-stipend.svg" copy="A stipend of $60,000 USD*, paid in 10 monthly installments."></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-insurance.svg" copy="One-time health insurance supplement for Fellows and their families, ranging from $3,500 for single Fellows to $7,000 for a couple with two or more children."></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-child.svg" copy="One-time childcare allotment of up to $6,000 for families with children."></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-computer.svg" copy="Allowance of up to $3,000 towards the purchase of laptop computer, digital cameras, recorders and computer software; fees for continuing studies or other courses, research fees or payments, to the extent related to the fellowship."></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-trips.svg" copy="All approved fellowship trips – domestic and international – are covered in full."></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-stipend.svg" copy="A stipend of $60,000 USD*, paid in 10 monthly installments"></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-insurance.svg" copy="A one-time health insurance supplement for Fellows and their families, ranging from $3,500 for single Fellows to $7,000 for a couple with two or more children"></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-child.svg" copy="A one-time childcare allotment of up to $6,000 for families with children."></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-computer.svg" copy="An allowance of up to $3,000 towards the purchase of laptop computer, digital cameras, recorders and computer software; fees for continuing studies or other courses, research fees or payments, to the extent related to the fellowship"></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-trips.svg" copy="All approved fellowship trips – domestic and international – are covered in full"></IconItem>
                 * Proposed fellowship amounts are gross amounts and may be reduced by applicable taxes in the various applicable jurisdictions. Read more <a href="#" onClick={this.switchToFAQ}>here</a>
               </div>
 
@@ -128,7 +128,7 @@ export default React.createClass({
               <div className="m-b-3">
                 <IconItem imgSrc="/assets/img/fellowships/icon-institution.svg" copy="Currently employed at a research institution"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-stipend.svg" copy="Able to accept outside funds for this fellowship directly"></IconItem>
-                <IconItem imgSrc="/assets/img/fellowships/icon-research.svg" copy="Currently an early-career researcher (i.e, graduate students, post-docs, research scientists, lecturers)"></IconItem>
+                <IconItem imgSrc="/assets/img/fellowships/icon-research.svg" copy="A current early-career researcher (i.e, graduate students, post-docs, research scientists, lecturers)"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-life.svg" copy="Specializing in the life sciences or natural sciences"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-travel.svg" copy="Able to travel"></IconItem>
                 <IconItem imgSrc="/assets/img/fellowships/icon-approve.svg" copy="Supported by their supervisors. As fellows will be based at their home institutions, please note that a letter of support from their supervisor is mandatory for consideration"></IconItem>


### PR DESCRIPTION
While this PR attempts to fix #467, I think that the `Stipends` section also faces a similar issue.

<img width="1144" alt="screen shot 2016-06-02 at 9 19 01 pm" src="https://cloud.githubusercontent.com/assets/1824298/15751547/1cac72ce-2908-11e6-8366-8841b9e4fdfb.png">

I propose:
- Removing periods from all bullet points in this section as well.
- Additionally, I'd prefer wording such that all the points start with an article. e.g: `A one-time allowance` or `An allowance of upto`.
- Rewording the last bullet point about `fellowship trips` to fit with verbiage at the top. Any ideas on how to go about this?