### PR TITLE
Fix #3 Study Group Map improvements 

### DIFF
--- a/app/react/pages/study-groups/join-study-group.jsx
+++ b/app/react/pages/study-groups/join-study-group.jsx
@@ -62,7 +62,7 @@ export default React.createClass({
             <p className="mb-3">A Study Group is a community of peers committed to learning and teaching each other. They’re fun, informal meetups allowing participants to share skills, experiences, and ideas around open science, open source, code, and community in research. The goal of the Mozilla Study Group Project is to support this kind of peer-to-peer study by providing a simple set of tools, template lesson plans, and access to an international community of like-minded researchers and avid learners in code.</p>
             <h3>Find a Study Group</h3>
             <div className="text-xs-center my-3">
-              <iframe width="100%" height="480" frameborder="0" src="https://auremoser.carto.com/builder/95be417c-ac31-11e6-b906-0ef7f98ade21/embed" allowfullscreen webkitallowfullscreen mozallowfullscreen oallowfullscreen msallowfullscreen></iframe>
+              <iframe width="100%" height="480" src="https://auremoser.carto.com/builder/95be417c-ac31-11e6-b906-0ef7f98ade21/embed" frameborder="0"></iframe>
             </div>
 
             <style>/* This is a filthy hack for use with columns later on.*/ /*{`.rc-collapse-item:nth-of-type(${middle}){break-after: column; border-bottom-width: 1px}`}*/</style>


### PR DESCRIPTION
@auremoser Eliminated the box shadow that outlines the top and left sides of the map.
This works only when added to the end of iframe tag:
```
frameborder="0"