### PR TITLE
Add adaptive filter component

### DIFF
--- a/app/react/components/adaptive-filter/adaptive-filter.jsx
+++ b/app/react/components/adaptive-filter/adaptive-filter.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { RadioFilter } from "mofo-ui";
+
+export default React.createClass({
+  propTypes: {
+    options: React.PropTypes.arrayOf(React.PropTypes.shape({
+      value: React.PropTypes.string.isRequired,
+      label: React.PropTypes.string.isRequired
+    }).isRequired).isRequired,
+    value: React.PropTypes.string,
+    initialChoice: React.PropTypes.string,
+    onChange: React.PropTypes.func
+  },
+  getInitialState(){
+    return {
+      activeFilter: this.props.value || this.props.initialChoice || this.props.options[0].value
+    };
+  },
+  onChange(choice){
+    if (this.props.onChange){
+      var filter = ((choice.target) ? choice.target.value : choice);
+
+      this.props.onChange(filter);
+    }
+  },
+  componentWillReceiveProps(nextProps){
+    // Able to bind to external state
+    if (nextProps.value !== this.state.activeFilter){
+      this.setState({
+        activeFilter: nextProps.value
+      });
+    }
+  },
+  render() {
+    return (
+      <div className="adaptive-filter">
+        <div className="hidden-xs-down">
+          <RadioFilter value={this.state.activeFilter} options={this.props.options} onChange={this.onChange}>
+          </RadioFilter>
+        </div>
+        <div className="hidden-sm-up">
+          <select value={this.state.activeFilter} onChange={this.onChange} className="c-select form-control wide">
+            {this.props.options.map(option => {
+              return <option value={option.value}>{option.label}</option>;
+            })}
+          </select>
+        </div>
+      </div>
+    );
+  }
+});

--- a/app/react/pages/projects/projects.jsx
+++ b/app/react/pages/projects/projects.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import ThreeUp from "../../components/three-up/three-up.jsx";
 import ProjectList from "../../components/project-list/project-list.jsx";
-import { RadioFilter } from "mofo-ui";
+import AdaptiveFilter from "../../components/adaptive-filter/adaptive-filter.jsx";
 
 import DebounceInput from 'react-debounce-input';
 import { Link } from 'react-router';
@@ -137,7 +137,9 @@ export default React.createClass({
                 })}
               </select>
             </div>
-            <RadioFilter options={sortOptions} initialChoice={this.state.sortBy} onChange={this.onSortChange}></RadioFilter>
+            <div className="col-xs-12 mb-1">
+              <AdaptiveFilter options={sortOptions} initialChoice={this.state.sortBy} onChange={this.onSortChange}></AdaptiveFilter>
+            </div>
           </div>
           <ProjectList projects={this.state.projects}/>
           <div className="text-xs-center">


### PR DESCRIPTION
fixes #353 and #373 
i preserved the same API as the `radioFilter` component, so changing the other occurrences should simply be changing the component from `radioFilter` to `AdaptiveFilter`, also styling should be done on a parent div.
Currently there's no sync btw the `radioFilter` and `select` components, it will be added by the next mofo-ui release, simply upgrading will enable the functionality, same for the `initialChoice` prop since its channeled to the new `value` prop, so now it only works for `select`.