### PR TITLE
remove outdated flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,5 @@
   },
   "devDependencies": {
     "imagemin-cli-preserve-dir-structure": "0.0.2"
-  },
-  "heroku-run-build-script": true
+  }
 }


### PR DESCRIPTION
We don't need that flag anymore.
ref MozillaFoundation/mofo-devops-private#208